### PR TITLE
Treat values as simple/array based on local lens

### DIFF
--- a/lib/puppet/provider/ssh_config/augeas.rb
+++ b/lib/puppet/provider/ssh_config/augeas.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:ssh_config).provide(:augeas, parent: Puppet::Type.type(:augea
   end
 
   def self.set_value(aug, base, path, label, value)
-    if label =~ %r{Ciphers|SendEnv|MACs|(HostKey|Kex)Algorithms|GlobalKnownHostsFile|PubkeyAcceptedKeyTypes}i
+    if parsed_as?("#{label} FOO\n", "#{label}/1", lens)
       set_array_value(aug, path, value)
     else
       set_simple_value(aug, base, path, label, value)

--- a/lib/puppet/provider/sshd_config/augeas.rb
+++ b/lib/puppet/provider/sshd_config/augeas.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:sshd_config).provide(:augeas, parent: Puppet::Type.type(:auge
   end
 
   def self.set_value(aug, base, path, label, value)
-    if label =~ %r{^(((Allow|Deny)(Groups|Users))|AcceptEnv|MACs|(HostKey|Kex)Algorithms|Ciphers)$}i
+    if parsed_as?("#{label} FOO\n", "#{label}/1", lens)
       set_array_value(aug, base, path, label, value)
     else
       set_simple_value(aug, base, path, label, value)


### PR DESCRIPTION
This code previously used an explicitly defined list of labels that were
treated as arrays and not simple values. This broke the sshd_config
provider for users with a version of the sshd lens from augeas 1.9.0 or
newer. To avoid breaking support for older users, and to be
forward-compatible with new versions of augeas that are aware of
additional array values, this change determines if a label is an array
or simple value by testing what the underlying augeas provider returns

Addresses #64 