### PR TITLE
Move Forge org to "puppet"

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
       repo: "puppetlabs/sshkeys_core"
       puppet_version: '>= 6.0.0'
   repositories:
-    augeasproviders_core:
-      repo: "git://github.com/hercules-team/augeasproviders_core.git"
+    augeasproviders_core: "https://github.com/voxpupuli/augeasproviders_core.git"
   symlinks:
     augeasproviders_ssh: "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1
+
+Change Forge org to `puppet` (project moved from herculestem to Vox Pupuli)
+
 ## 4.0.0
 
 - Deprecate support for Augeas < 1.0.0

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,15 @@
 {
-  "name": "herculesteam-augeasproviders_ssh",
-  "version": "4.0.0",
-  "author": "Raphael Pinson",
+  "name": "puppet-augeasproviders_ssh",
+  "version": "4.0.1",
+  "author": "Vox Pupuli",
   "summary": "Augeas-based ssh types and providers for Puppet",
   "license": "Apache-2.0",
-  "source": "https://github.com/hercules-team/augeasproviders_ssh",
-  "project_page": "https://github.com/hercules-team/augeasproviders_ssh",
-  "issues_url": "https://github.com/hercules-team/augeasproviders_ssh/issues",
+  "source": "https://github.com/voxpupuli/augeasproviders_ssh",
+  "project_page": "https://github.com/voxpupuli/augeasproviders_ssh",
+  "issues_url": "https://github.com/voxpupuli/augeasproviders_ssh/issues",
   "dependencies": [
     {
-      "name": "herculesteam/augeasproviders_core",
+      "name": "puppet/augeasproviders_core",
       "version_requirement": ">=2.4.0 <4.0.0"
     }
   ],


### PR DESCRIPTION
The Forge needs an augeasproviders_ssh that is updated to resolve with puppet/augeasproviders_core