### PR TITLE
Add support of PubkeyAcceptedKeyTypes for ssh_config

### DIFF
--- a/lib/puppet/provider/ssh_config/augeas.rb
+++ b/lib/puppet/provider/ssh_config/augeas.rb
@@ -61,7 +61,7 @@ Puppet::Type.type(:ssh_config).provide(:augeas, parent: Puppet::Type.type(:augea
   end
 
   def self.set_value(aug, base, path, label, value)
-    if label =~ %r{Ciphers|SendEnv|MACs|(HostKey|Kex)Algorithms|GlobalKnownHostsFile}i
+    if label =~ %r{Ciphers|SendEnv|MACs|(HostKey|Kex)Algorithms|GlobalKnownHostsFile|PubkeyAcceptedKeyTypes}i
       set_array_value(aug, path, value)
     else
       set_simple_value(aug, base, path, label, value)


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for managing `PubkeyAcceptedKeyTypes` augeas entry for `ssh_config`.
Prior to this change, the ssh-agent refuses the use of legacy ssh key (eg sha256). Hence we need to introduce PubkeyAcceptedKeyTypes in `/etc/ssh/ssh_config` file to support this legacy mode.


