### PR TITLE
Update git:// URLs to use https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "augeas"]
 	path = spec/fixtures/augeas
-	url = git://github.com/hercules-team/augeas.git
+	url = https://github.com/hercules-team/augeas.git


### PR DESCRIPTION
#### Pull Request (PR) description
This module still uses old `git://` URLs.
For consistency with other `augeasprovider`s and also with https://github.blog/2021-09-01-improving-git-protocol-security-github/ it should use `https://` instead

#### This Pull Request (PR) fixes the following issues
* None, but I can report one if you prefer