### PR TITLE
Drop support for multiple EOL OSes

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -25,7 +24,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]
@@ -33,7 +31,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -41,8 +38,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },
@@ -63,15 +58,12 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "35",
-        "36",
         "40"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Drop support for:

* Debian 10
* Ubuntu 18.04
* RedHat 7
* CentOS 7 & 8
* Fedora 35 & 36
* OracleLinux 7

